### PR TITLE
ADS-3428: Add current variation

### DIFF
--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect } from "react";
 
-const NostoHome: React.FC = () => {
+interface NostoTaggingProps {
+  currentVariation: string;
+}
+
+const NostoHome: React.FC<NostoTaggingProps> = ({
+  currentVariation
+}) => {
   useEffect(() => {
     // @ts-ignore
     window.nostojs((api) => {
@@ -22,6 +28,7 @@ const NostoHome: React.FC = () => {
       <div className="nosto_page_type" style={{ display: "none" }}>
         front
       </div>
+      <div class="nosto_variation" style="display: none;">{currentVariation}</div>
     </>
   );
 };

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,12 +1,6 @@
 import React, { useEffect } from "react";
 
-interface NostoTaggingProps {
-  currentVariation: string;
-}
-
-const NostoHome: React.FC<NostoTaggingProps> = ({
-  currentVariation
-}) => {
+const NostoHome: React.FC = () => {
   useEffect(() => {
     // @ts-ignore
     window.nostojs((api) => {
@@ -28,7 +22,6 @@ const NostoHome: React.FC<NostoTaggingProps> = ({
       <div className="nosto_page_type" style={{ display: "none" }}>
         front
       </div>
-      { currentVariation && <div className="nosto_variation" style={{ display: "none" }}>{currentVariation}</div> }
     </>
   );
 };

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -28,7 +28,7 @@ const NostoHome: React.FC<NostoTaggingProps> = ({
       <div className="nosto_page_type" style={{ display: "none" }}>
         front
       </div>
-      <div class="nosto_variation" style="display: none;">{currentVariation}</div>
+      { currentVariation && <div className="nosto_variation" style={{ display: "none" }}>{currentVariation}</div> }
     </>
   );
 };

--- a/src/components/Tagging/index.tsx
+++ b/src/components/Tagging/index.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from "react";
+
+interface NostoTaggingProps {
+  currentVariation: string;
+}
+
+const NostoTagging: React.FC<NostoTaggingProps> = ({
+  currentVariation
+}) => {
+  useEffect(() => {
+    // @ts-ignore
+  }, []);
+
+  return (
+    <>
+      { currentVariation && <div className="nosto_variation" style={{ display: "none" }}>{currentVariation}</div> }
+    </>
+  );
+};
+
+export default NostoTagging;

--- a/src/index.client.ts
+++ b/src/index.client.ts
@@ -29,3 +29,5 @@ export { default as NostoPlacement } from "./components/Placement";
 export { default as NostoProvider } from "./components/Provider";
 // noinspection JSUnusedGlobalSymbols
 export { default as NostoSession } from "./components/Session";
+// noinspection JSUnusedGlobalSymbols
+export { default as NostoTagging } from "./components/Tagging";


### PR DESCRIPTION
This PR introduces a new Tagging component which will act as a placeholder for all the Nosto tagging data.
As a first step, we are adding `nosto_variation` and in upcoming PR we may include other information from `nosto-tagging.liquid.html`.

This PR has changes in two places
1. [nosto-react](https://github.com/Nosto/nosto-react)
2. [nosto-shopify-hydropgen](https://github.com/Nosto/nosto-shopify-hydrogen)

## JIRA
[ADS-3428](https://nostosolutions.atlassian.net/browse/ADS-3428)