### PR TITLE
Add loadScript flag

### DIFF
--- a/spec/nosto.load.spec.tsx
+++ b/spec/nosto.load.spec.tsx
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest"
-import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { render, renderHook } from "@testing-library/react"
 import "@testing-library/jest-dom/vitest"
 import { NostoProvider, NostoHome } from "../src/index"
+import { useLoadClientScript } from "../src/hooks"
 
-describe("Nosto client script loading", () => {
-  it("verify Nosto is not loaded twice", () => {
+describe("Nosto client script", () => {
+  it("verify is not loaded twice", () => {
     // @ts-expect-error dummy placeholder for Nosto iframe window scope  
     window.nosto = {}
 
@@ -37,5 +38,25 @@ describe("Nosto client script loading", () => {
     expect(document.querySelector("[nosto-client-script]")).toBeInTheDocument()
     expect(document.querySelector("[nosto-client-script]")?.getAttribute("nosto-language")).toBe("en")
     expect(document.querySelector("[nosto-client-script]")?.getAttribute("nosto-market-id")).toBe("123")
+  })
+
+  it("should set loaded state to true when client is loaded", () => {
+    const hook = renderHook(() => useLoadClientScript({ loadScript: false, account: "shopify-11368366139" }))
+    expect(hook.result.current.clientScriptLoaded).toBe(true)
+  })
+
+  it("remove existing scripts before loading new ones", () => {
+    const existingScript = document.createElement("script")
+    existingScript.setAttribute("nosto-client-script", "")
+    document.body.appendChild(existingScript)
+
+    const nostoSandbox = document.createElement("div")
+    nostoSandbox.id = "nosto-sandbox"
+    document.body.appendChild(nostoSandbox)
+
+    renderHook(() => useLoadClientScript({ loadScript: true, account: "shopify-11368366139", shopifyMarkets: { marketId: "123", language: "en" } }))
+
+    expect(document.body.contains(existingScript)).toBe(false)
+    expect(document.body.contains(nostoSandbox)).toBe(false)
   })
 })

--- a/spec/nosto.load.spec.tsx
+++ b/spec/nosto.load.spec.tsx
@@ -1,8 +1,7 @@
-import { describe, expect, it, vi } from "vitest"
-import { render, renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { render } from "@testing-library/react"
 import "@testing-library/jest-dom/vitest"
 import { NostoProvider, NostoHome } from "../src/index"
-import { useLoadClientScript } from "../src/hooks"
 
 describe("Nosto client script", () => {
   it("verify is not loaded twice", () => {
@@ -38,25 +37,5 @@ describe("Nosto client script", () => {
     expect(document.querySelector("[nosto-client-script]")).toBeInTheDocument()
     expect(document.querySelector("[nosto-client-script]")?.getAttribute("nosto-language")).toBe("en")
     expect(document.querySelector("[nosto-client-script]")?.getAttribute("nosto-market-id")).toBe("123")
-  })
-
-  it("should set loaded state to true when client is loaded", () => {
-    const hook = renderHook(() => useLoadClientScript({ loadScript: false, account: "shopify-11368366139" }))
-    expect(hook.result.current.clientScriptLoaded).toBe(true)
-  })
-
-  it("remove existing scripts before loading new ones", () => {
-    const existingScript = document.createElement("script")
-    existingScript.setAttribute("nosto-client-script", "")
-    document.body.appendChild(existingScript)
-
-    const nostoSandbox = document.createElement("div")
-    nostoSandbox.id = "nosto-sandbox"
-    document.body.appendChild(nostoSandbox)
-
-    renderHook(() => useLoadClientScript({ loadScript: true, account: "shopify-11368366139", shopifyMarkets: { marketId: "123", language: "en" } }))
-
-    expect(document.body.contains(existingScript)).toBe(false)
-    expect(document.body.contains(nostoSandbox)).toBe(false)
   })
 })

--- a/spec/useLoadClientScript.spec.tsx
+++ b/spec/useLoadClientScript.spec.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { renderHook } from "@testing-library/react"
+import { useLoadClientScript } from "../src/hooks"
+
+describe("useLoadClientScript", () => {
+  it("set loaded state to true when client is loaded", () => {
+    const hook = renderHook(() => useLoadClientScript({ loadScript: false, account: "shopify-11368366139" }))
+    expect(hook.result.current.clientScriptLoaded).toBe(true)
+  })
+
+  it("remove existing scripts before loading new ones", () => {
+    const existingScript = document.createElement("script")
+    existingScript.setAttribute("nosto-client-script", "")
+    document.body.appendChild(existingScript)
+
+    const nostoSandbox = document.createElement("div")
+    nostoSandbox.id = "nosto-sandbox"
+    document.body.appendChild(nostoSandbox)
+
+    renderHook(() => useLoadClientScript({ loadScript: true, account: "shopify-11368366139", shopifyMarkets: { marketId: "123", language: "en" } }))
+
+    expect(document.body.contains(existingScript)).toBe(false)
+    expect(document.body.contains(nostoSandbox)).toBe(false)
+  })
+})

--- a/spec/useLoadClientScript.spec.tsx
+++ b/spec/useLoadClientScript.spec.tsx
@@ -3,12 +3,12 @@ import { renderHook } from "@testing-library/react"
 import { useLoadClientScript } from "../src/hooks"
 
 describe("useLoadClientScript", () => {
-  it("set loaded state to true when client is loaded", () => {
-    const hook = renderHook(() => useLoadClientScript({ loadScript: false, account: "shopify-11368366139" }))
-    expect(hook.result.current.clientScriptLoaded).toBe(true)
+  it("set loaded state to true when client is loaded externally", () => {
+    const { result } = renderHook(() => useLoadClientScript({ loadScript: false, account: "shopify-11368366139" }))
+    expect(result.current.clientScriptLoaded).toBe(true)
   })
 
-  it("remove existing scripts before loading new ones", () => {
+  it("remove existing Shopify markets related scripts before loading new ones", () => {
     const existingScript = document.createElement("script")
     existingScript.setAttribute("nosto-client-script", "")
     document.body.appendChild(existingScript)
@@ -17,7 +17,7 @@ describe("useLoadClientScript", () => {
     nostoSandbox.id = "nosto-sandbox"
     document.body.appendChild(nostoSandbox)
 
-    renderHook(() => useLoadClientScript({ loadScript: true, account: "shopify-11368366139", shopifyMarkets: { marketId: "123", language: "en" } }))
+    const { result } = renderHook(() => useLoadClientScript({ account: "shopify-11368366139", shopifyMarkets: { marketId: "123", language: "en" } }))
 
     expect(document.body.contains(existingScript)).toBe(false)
     expect(document.body.contains(nostoSandbox)).toBe(false)

--- a/src/components/NostoProvider.tsx
+++ b/src/components/NostoProvider.tsx
@@ -38,6 +38,10 @@ export interface NostoProviderProps {
     language?: string
     marketId?: string | number
   }
+  /**
+   * Load nosto script (should be false if loading the script outside of nosto-react)
+   */
+  loadScript?: boolean
 }
 
 /**

--- a/src/hooks/useLoadClientScript.ts
+++ b/src/hooks/useLoadClientScript.ts
@@ -38,7 +38,9 @@ export function useLoadClientScript(props: NostoScriptProps) {
       window.nostojs(api => api.setAutoLoad(false))
     }
 
-    if (loadScript) {
+    if (!loadScript) {
+      setClientScriptLoadedState(true)
+    } else {
       // Load Nosto client script if not already loaded externally
       if (!isNostoLoaded() && !shopifyMarkets) {
         const urlPartial = `/include/${account}`
@@ -76,11 +78,6 @@ export function useLoadClientScript(props: NostoScriptProps) {
           document.body.appendChild(script)
         }
       }
-    } else {
-      window.nosto?.reload({
-        site: "localhost",
-      })
-      setClientScriptLoadedState(true)
     }
   }, [clientScriptLoadedState, shopifyMarkets])
 

--- a/src/hooks/useLoadClientScript.ts
+++ b/src/hooks/useLoadClientScript.ts
@@ -12,6 +12,7 @@ export function useLoadClientScript(props: NostoScriptProps) {
 
   useEffect(() => {
     const scriptOnload = () => {
+      // Override for production scripts to work in unit tests
       if ("nostoReactTest" in window) {
         window.nosto?.reload({
           site: "localhost"

--- a/src/hooks/useLoadClientScript.ts
+++ b/src/hooks/useLoadClientScript.ts
@@ -3,10 +3,10 @@ import { isNostoLoaded } from "../components/helpers"
 import type { NostoClient } from "../types"
 import type { NostoProviderProps } from "../components/NostoProvider"
 
-type NostoScriptProps = Pick<NostoProviderProps, "account" | "host" | "shopifyMarkets">
+type NostoScriptProps = Pick<NostoProviderProps, "account" | "host" | "shopifyMarkets" | "loadScript">
 
 export function useLoadClientScript(props: NostoScriptProps) {
-  const { host, account, shopifyMarkets } = props
+  const { host, account, shopifyMarkets, loadScript = true } = props
   const [clientScriptLoadedState, setClientScriptLoadedState] = useState(false)
   const clientScriptLoaded = useMemo(() => clientScriptLoadedState, [clientScriptLoadedState])
 
@@ -38,44 +38,50 @@ export function useLoadClientScript(props: NostoScriptProps) {
       window.nostojs(api => api.setAutoLoad(false))
     }
 
-    // Load Nosto client script if not already loaded externally
-    if (!isNostoLoaded() && !shopifyMarkets) {
-      const urlPartial = `/include/${account}`
-      const script = createScriptElement(urlPartial)
-      script.onload = scriptOnload
-      document.body.appendChild(script)
-    }
-
-    // Load Shopify Markets scripts
-    if (shopifyMarkets) {
-      const existingScript = document.querySelector("[nosto-client-script]")
-      const marketId = String(shopifyMarkets?.marketId || "")
-      const language = shopifyMarkets?.language || ""
-
-      const existingScriptAttributes =
-      existingScript?.getAttribute("nosto-language") !== language ||
-      existingScript?.getAttribute("nosto-market-id") !== marketId
-
-      if (!existingScript || existingScriptAttributes) {
-        if (clientScriptLoadedState) {
-          setClientScriptLoadedState(false)
-        }
-
-        const nostoSandbox = document.querySelector("#nosto-sandbox")
-
-        existingScript?.parentNode?.removeChild(existingScript)
-        nostoSandbox?.parentNode?.removeChild(nostoSandbox)
-
-        const urlPartial =
-        `/script/shopify/market/nosto.js?merchant=${account}&market=${marketId}&locale=${language.toLowerCase()}`
+    if (loadScript) {
+      // Load Nosto client script if not already loaded externally
+      if (!isNostoLoaded() && !shopifyMarkets) {
+        const urlPartial = `/include/${account}`
         const script = createScriptElement(urlPartial)
-        script.setAttribute("nosto-language", language)
-        script.setAttribute("nosto-market-id", marketId)
         script.onload = scriptOnload
         document.body.appendChild(script)
       }
-    }
 
+      // Load Shopify Markets scripts
+      if (shopifyMarkets) {
+        const existingScript = document.querySelector("[nosto-client-script]")
+        const marketId = String(shopifyMarkets?.marketId || "")
+        const language = shopifyMarkets?.language || ""
+
+        const existingScriptAttributes =
+          existingScript?.getAttribute("nosto-language") !== language ||
+          existingScript?.getAttribute("nosto-market-id") !== marketId
+
+        if (!existingScript || existingScriptAttributes) {
+          if (clientScriptLoadedState) {
+            setClientScriptLoadedState(false)
+          }
+
+          const nostoSandbox = document.querySelector("#nosto-sandbox")
+
+          existingScript?.parentNode?.removeChild(existingScript)
+          nostoSandbox?.parentNode?.removeChild(nostoSandbox)
+
+          const urlPartial =
+            `/script/shopify/market/nosto.js?merchant=${account}&market=${marketId}&locale=${language.toLowerCase()}`
+          const script = createScriptElement(urlPartial)
+          script.setAttribute("nosto-language", language)
+          script.setAttribute("nosto-market-id", marketId)
+          script.onload = scriptOnload
+          document.body.appendChild(script)
+        }
+      }
+    } else {
+      window.nosto?.reload({
+        site: "localhost",
+      })
+      setClientScriptLoadedState(true)
+    }
   }, [clientScriptLoadedState, shopifyMarkets])
 
   return { clientScriptLoaded }

--- a/src/hooks/useLoadClientScript.ts
+++ b/src/hooks/useLoadClientScript.ts
@@ -39,44 +39,45 @@ export function useLoadClientScript(props: NostoScriptProps) {
     }
 
     if (!loadScript) {
-      setClientScriptLoadedState(true)
-    } else {
-      // Load Nosto client script if not already loaded externally
-      if (!isNostoLoaded() && !shopifyMarkets) {
-        const urlPartial = `/include/${account}`
+      scriptOnload()
+      return
+    }
+
+    // Load Nosto client script if not already loaded externally
+    if (!isNostoLoaded() && !shopifyMarkets) {
+      const urlPartial = `/include/${account}`
+      const script = createScriptElement(urlPartial)
+      script.onload = scriptOnload
+      document.body.appendChild(script)
+    }
+
+    // Load Shopify Markets scripts
+    if (shopifyMarkets) {
+      const existingScript = document.querySelector("[nosto-client-script]")
+      const marketId = String(shopifyMarkets?.marketId || "")
+      const language = shopifyMarkets?.language || ""
+
+      const existingScriptAttributes =
+        existingScript?.getAttribute("nosto-language") !== language ||
+        existingScript?.getAttribute("nosto-market-id") !== marketId
+
+      if (!existingScript || existingScriptAttributes) {
+        if (clientScriptLoadedState) {
+          setClientScriptLoadedState(false)
+        }
+
+        const nostoSandbox = document.querySelector("#nosto-sandbox")
+
+        existingScript?.parentNode?.removeChild(existingScript)
+        nostoSandbox?.parentNode?.removeChild(nostoSandbox)
+
+        const urlPartial =
+          `/script/shopify/market/nosto.js?merchant=${account}&market=${marketId}&locale=${language.toLowerCase()}`
         const script = createScriptElement(urlPartial)
+        script.setAttribute("nosto-language", language)
+        script.setAttribute("nosto-market-id", marketId)
         script.onload = scriptOnload
         document.body.appendChild(script)
-      }
-
-      // Load Shopify Markets scripts
-      if (shopifyMarkets) {
-        const existingScript = document.querySelector("[nosto-client-script]")
-        const marketId = String(shopifyMarkets?.marketId || "")
-        const language = shopifyMarkets?.language || ""
-
-        const existingScriptAttributes =
-          existingScript?.getAttribute("nosto-language") !== language ||
-          existingScript?.getAttribute("nosto-market-id") !== marketId
-
-        if (!existingScript || existingScriptAttributes) {
-          if (clientScriptLoadedState) {
-            setClientScriptLoadedState(false)
-          }
-
-          const nostoSandbox = document.querySelector("#nosto-sandbox")
-
-          existingScript?.parentNode?.removeChild(existingScript)
-          nostoSandbox?.parentNode?.removeChild(nostoSandbox)
-
-          const urlPartial =
-            `/script/shopify/market/nosto.js?merchant=${account}&market=${marketId}&locale=${language.toLowerCase()}`
-          const script = createScriptElement(urlPartial)
-          script.setAttribute("nosto-language", language)
-          script.setAttribute("nosto-market-id", marketId)
-          script.onload = scriptOnload
-          document.body.appendChild(script)
-        }
       }
     }
   }, [clientScriptLoadedState, shopifyMarkets])


### PR DESCRIPTION
Adds `loadScript` flag which enables user to control whether the Nosto script is loaded externally. If set to false, the script should be loaded externally. Default value is `true`. 