### PR TITLE
Remove session level responseMode override

### DIFF
--- a/spec/session.spec.tsx
+++ b/spec/session.spec.tsx
@@ -40,7 +40,7 @@ test("Session render", async () => {
         type: "loggedin"
       },
       events: [],
-      response_mode: "HTML",
+      response_mode: "JSON_ORIGINAL",
       url: "http://localhost/"
     },
     {

--- a/src/components/NostoProvider.tsx
+++ b/src/components/NostoProvider.tsx
@@ -92,6 +92,12 @@ export default function NostoProvider(props: NostoProviderProps) {
 
   const { clientScriptLoaded } = useLoadClientScript(props)
 
+  if (clientScriptLoaded) {
+    window.nostojs(api => {
+      api.defaultSession().setVariation(currentVariation!).setResponseMode(responseMode)
+    })
+  }
+
   return (
     <NostoContext.Provider
       value={{

--- a/src/components/NostoSession.tsx
+++ b/src/components/NostoSession.tsx
@@ -45,7 +45,6 @@ export function useNostoSession({ cart, customer }: NostoSessionProps = {}) {
       window.nostojs(api => {
         api
           .defaultSession()
-          .setResponseMode("HTML")
           .setCart(currentCart)
           .setCustomer(currentCustomer)
           .viewOther()

--- a/src/hooks/useNostoApi.ts
+++ b/src/hooks/useNostoApi.ts
@@ -8,15 +8,12 @@ export function useNostoApi(
   deps?: DependencyList,
   flags?: { deep?: boolean }
 ): void {
-  const { clientScriptLoaded, currentVariation, responseMode } = useNostoContext()
+  const { clientScriptLoaded } = useNostoContext()
   const useEffectFn = flags?.deep ? useDeepCompareEffect : useEffect
 
   useEffectFn(() => {
     if (clientScriptLoaded) {
-      window.nostojs(api => {
-        api.defaultSession().setVariation(currentVariation!).setResponseMode(responseMode)
-        cb(api)
-      })
+      window.nostojs(cb)
     }
-  }, [clientScriptLoaded, currentVariation, responseMode, ...(deps ?? [])])
+  }, [clientScriptLoaded, ...(deps ?? [])])
 }


### PR DESCRIPTION
The session level responseMode sets responseMode for all usage
As the NostoSession component doesn't use any elements, the responseMode override is not needed