### PR TITLE
Align prop types

### DIFF
--- a/src/hooks/useNostoOrder.tsx
+++ b/src/hooks/useNostoOrder.tsx
@@ -2,12 +2,13 @@ import { snakeize } from "../utils/snakeize"
 import { Order } from "../types"
 import { useRenderCampaigns } from "./useRenderCampaigns"
 import { useNostoApi } from "./useNostoApi"
+import { ToCamelCase } from "../utils/types"
 
 /**
  * @group Hooks
  */
 export type NostoOrderProps = {
-  order: Order
+  order: Order | ToCamelCase<Order>
   placements?: string[]
 }
 

--- a/src/hooks/useNostoSession.tsx
+++ b/src/hooks/useNostoSession.tsx
@@ -4,15 +4,12 @@ import { ToCamelCase } from "../utils/types"
 import { useNostoContext } from "./useNostoContext"
 import { useDeepCompareEffect } from "./useDeepCompareEffect"
 
-type Cart = CartSnakeCase | ToCamelCase<CartSnakeCase>
-type Customer = CustomerSnakeCase | ToCamelCase<CustomerSnakeCase>
-
 /**
  * @group Hooks
  */
 export type NostoSessionProps = {
-  cart?: Cart
-  customer?: Customer
+  cart?: CartSnakeCase | ToCamelCase<CartSnakeCase>
+  customer?: CustomerSnakeCase | ToCamelCase<CustomerSnakeCase>
 }
 
 /**


### PR DESCRIPTION
Makes sure that NostoSession & NostoOrder snake case / camelCase aligned prop fields are declared in the same way