### PR TITLE
fix: move react to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     "src"
   ],
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "@nosto/nosto-js": "*"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1 || ^19.0.0",
+    "react-dom": "^18.3.1 || ^19.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.8",
@@ -47,6 +49,8 @@
     "eslint-plugin-promise": "^7.1.0",
     "eslint-plugin-react": "^7.33.2",
     "prettier": "^3.3.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-router": "^7.0.1",
     "react-router-dom": "^7.0.1",
     "rimraf": "^6.0.1",

--- a/src/hooks/useRenderCampaigns.tsx
+++ b/src/hooks/useRenderCampaigns.tsx
@@ -4,7 +4,7 @@ import { Recommendation } from "../types"
 import { useNostoContext } from "./useNostoContext"
 import { RecommendationComponent } from "../context"
 import { ActionResponse, API } from "@nosto/nosto-js/client"
-import { nostojs } from "@nosto/nosto-js"
+import { nostojs, isNostoLoaded } from "@nosto/nosto-js"
 
 type CampaignData = Pick<ActionResponse, "campaigns" | "recommendations">
 
@@ -20,8 +20,7 @@ function RecommendationComponentWrapper(props: {
 }
 
 function injectCampaigns(data: CampaignData) {
-  // @ts-expect-error not defined
-  if (!window.nostojs) {
+  if (!isNostoLoaded()) {
     throw new Error("Nosto has not yet been initialized")
   }
   nostojs(api => {


### PR DESCRIPTION
Moves React to peer dependencies and uses a proper check for the client script being loaded.