### PR TITLE
Externalise router dom deps

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,30 +8,31 @@ export default defineConfig({
     react(),
     dts({
       rollupTypes: true,
-      exclude: ["spec/*"],
-    }),
+      exclude: ["spec/*"]
+    })
   ],
   build: {
     lib: {
       entry: path.resolve(__dirname, "src/index.ts"),
       name: "@nosto/nosto-react",
       formats: ["es", "umd"],
-      fileName: format => `index.${format}.js`,
+      fileName: format => `index.${format}.js`
     },
     rollupOptions: {
-      external: ["react", "react-dom", "react/jsx-runtime"],
+      external: ["react", "react-dom", "react/jsx-runtime", "react-router-dom"],
       output: {
         globals: {
           react: "React",
           "react/jsx-runtime": "react/jsx-runtime",
-          "react-dom": "ReactDOM"
-        },
-      },
-    },
+          "react-dom": "ReactDOM",
+          "react-router-dom": "react-router-dom"
+        }
+      }
+    }
   },
   test: {
     include: ["*.spec.*"],
     dir: "spec",
-    setupFiles: ['./spec/setup.js']
-  },
+    setupFiles: ["./spec/setup.js"]
+  }
 })


### PR DESCRIPTION
`react-router-dom` deps needs to be externalized to avoid react being bundled into the output
https://github.com/Nosto/nosto-react/issues/247

BTW, the nosto-react library includes the following deps

```
── @nosto/nosto-js@1.0.9
├── @testing-library/jest-dom@6.6.3
├── @testing-library/react@16.1.0
├── @testing-library/user-event@14.5.2
├── @types/react-dom@18.3.1
├── @types/react@18.3.12
├── @types/user-event@4.1.3
├── @vitejs/plugin-react@4.3.4
├── eslint-plugin-promise@7.2.1
├── eslint-plugin-react@7.37.2
├── eslint@9.17.0
├── prettier@3.4.2
├── react-dom@18.3.1
├── react-router-dom@7.0.2
├── react-router@7.0.2
├── react@18.3.1
├── rimraf@6.0.1
├── typedoc@0.27.5
├── typescript-eslint@8.18.1
├── typescript@5.7.2
├── vite-plugin-dts@4.3.0
├── vite@6.0.3
└── vitest@2.1.8
```