### PR TITLE
Add accidently dropped autoLoad false back

### DIFF
--- a/spec/navigation.spec.tsx
+++ b/spec/navigation.spec.tsx
@@ -62,11 +62,11 @@ function Main() {
 }
 
 test("navigation events", async () => {
+  // start collecting prequest events before rendering to make sure to catch all events
+  const requests = listenTo("prerequest")
   render(<Main />)
 
   await waitForRecommendations(3)
-
-  const requests = listenTo("prerequest")
 
   function verifyEvents(given: unknown[]) {
     expect(requests).toEqual(given)

--- a/spec/useLoadClientScript.spec.tsx
+++ b/spec/useLoadClientScript.spec.tsx
@@ -4,6 +4,7 @@ import { useLoadClientScript } from "../src/hooks/useLoadClientScript"
 import scriptLoader from "../src/hooks/scriptLoader"
 import "@testing-library/jest-dom/vitest"
 import { nostojs, isNostoLoaded } from "@nosto/nosto-js"
+import { mockNostojs } from "@nosto/nosto-js/testing"
 
 function loadClientScript(merchant: string) {
   const script = document.createElement("script")
@@ -38,6 +39,18 @@ describe("useLoadClientScript", () => {
     expect(hook.result.current.clientScriptLoaded).toBe(true)
     expect(isNostoLoaded()).toBeTruthy()
     expect(getScriptSources()).toEqual([`https://connect.nosto.com/include/${testAccount}`])
+  })
+
+  it("sets auto load to false", async () => {
+    const apiMock = {
+      setAutoLoad: vi.fn()
+    }
+    mockNostojs(apiMock)
+    const hook = renderHook(() => useLoadClientScript({ account: testAccount }))
+    await new Promise(nostojs)
+
+    hook.rerender()
+    expect(apiMock.setAutoLoad).toHaveBeenCalled()
   })
 
   it("support custom script loaders", async () => {

--- a/src/hooks/useLoadClientScript.ts
+++ b/src/hooks/useLoadClientScript.ts
@@ -22,6 +22,7 @@ export function useLoadClientScript(props: NostoScriptProps) {
     }
 
     initNostoStub()
+    nostojs(api => api.setAutoLoad(false))
 
     if (!loadScript) {
       nostojs(scriptOnload)


### PR DESCRIPTION
The call to set autoLoad to false was accidently dropped.
Adding it back makes sure that only Session API based ev1 calls are made

Commit that caused the issue https://github.com/Nosto/nosto-react/commit/411424ce8e9f8c92e5b302031c593283e3ba1f1e