### PR TITLE
feat: migrate to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 
@@ -52,7 +52,7 @@ jobs:
               "master"
             ]
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT_TOKEN }}
 
   publish-docs:
     needs: release


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request makes a minor update to the release workflow configuration. The change updates the environment variable used for the GitHub token.

- Updated the `GITHUB_TOKEN` environment variable in `.github/workflows/release.yml` to use `${{ secrets.GITHUB_TOKEN }}` instead of `${{ secrets.RELEASE_PAT_TOKEN }}`.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1475

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
