### PR TITLE
fix: semantic_version 25.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         id: semantic
         with:
-          semantic_version: 24.2.3
+          semantic_version: 25.0.2
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request updates the semantic release configuration to use a newer version of the semantic release tool.

Release workflow update:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L46-R46): Upgraded the `semantic_version` for `cycjimmy/semantic-release-action` from `24.2.3` to `25.0.2`, ensuring the release workflow uses the latest features and fixes.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1475

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
